### PR TITLE
change quotation marks used in svg bg images

### DIFF
--- a/js/h5p-shape.js
+++ b/js/h5p-shape.js
@@ -207,7 +207,7 @@ H5P.NDLAShape = (function ($) {
     }
 
     const encoded = encodeURIComponent(uri);
-    const backgroundImage = `url('data:image/svg+xml;utf8,${encoded}')`;
+    const backgroundImage = `url("data:image/svg+xml;utf8,${encoded}")`;
     css['background-image'] = backgroundImage;
     css['background-size'] = 'cover';
 


### PR DESCRIPTION
SVG attribute's quotation marks aren't escaped, and they break the CSS `background-image` if
the value is something like `url('<svg my-attribute='' />')`. Because the SVGs use single quotation
marks, the CSS `url` value needs to use double.